### PR TITLE
Horizontal scrolling for ribbon groups inside ribbon tab

### DIFF
--- a/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
+++ b/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
@@ -33,10 +33,11 @@ import javafx.scene.control.Tab;
 import javafx.scene.layout.HBox;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.scene.control.ScrollPane;
 import javafx.scene.input.ScrollEvent;
 
 public class RibbonTab extends Tab {
-//    public static final int CONTENT_HEIGHT = 70;
 
     private static final String DEFAULT_STYLE_CLASS = "ribbon-tab";
 
@@ -45,6 +46,8 @@ public class RibbonTab extends Tab {
     private ObservableList<RibbonGroup> ribbonGroups;
 
     private String contextualColor;
+
+    private ScrollPane scrollPane;
 
     public RibbonTab() {
         init();
@@ -58,14 +61,27 @@ public class RibbonTab extends Tab {
     private void init() {
         ribbonGroups = FXCollections.observableArrayList();
         content = new HBox();
+        scrollPane = new ScrollPane(content);
+        scrollPane.setHbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
+        scrollPane.setVbarPolicy(ScrollPane.ScrollBarPolicy.NEVER);
 
-        this.setContent(content);
+        this.setContent(scrollPane);
 
-        final double dx = 10;
+        final double dx = 0.100;
+        AtomicReference<Double> intendedHValue = new AtomicReference<>();
 
         content.setOnScroll((ScrollEvent s) -> {
-            double translate = content.getTranslateX() + (s.getDeltaY() > 0 ? +dx : -dx);
-            content.setTranslateX(translate);
+
+            intendedHValue.set(scrollPane.getHvalue()
+                    + (s.getDeltaY() > 0 ? +dx : -dx));
+
+            if (intendedHValue.get() < scrollPane.getHmin()) {
+                scrollPane.setHvalue(scrollPane.getHmin());
+            } else if (intendedHValue.get() > scrollPane.getHmax()) {
+                scrollPane.setHvalue(scrollPane.getHmax());
+            } else {
+                scrollPane.setHvalue(intendedHValue.get());
+            }
         });
 
         setClosable(false);

--- a/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
+++ b/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
@@ -24,7 +24,6 @@
  *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
 package com.pixelduke.control.ribbon;
 
 import javafx.collections.FXCollections;
@@ -34,9 +33,14 @@ import javafx.scene.control.Tab;
 import javafx.scene.layout.HBox;
 
 import java.util.List;
+import javafx.event.EventHandler;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
 
 public class RibbonTab extends Tab {
 //    public static final int CONTENT_HEIGHT = 70;
+
     private static final String DEFAULT_STYLE_CLASS = "ribbon-tab";
 
     private HBox content;
@@ -45,13 +49,11 @@ public class RibbonTab extends Tab {
 
     private String contextualColor;
 
-    public RibbonTab()
-    {
+    public RibbonTab() {
         init();
     }
 
-    public RibbonTab(String title)
-    {
+    public RibbonTab(String title) {
         super(title);
         init();
     }
@@ -59,53 +61,52 @@ public class RibbonTab extends Tab {
     private void init() {
         ribbonGroups = FXCollections.observableArrayList();
         content = new HBox();
-//        content.setMinHeight(CONTENT_HEIGHT);
+
         this.setContent(content);
+
+        final double dx = 10;
+
+        content.setOnScroll((ScrollEvent s) -> {
+            double translate = content.getTranslateX() + (s.getDeltaY() > 0 ? +dx : -dx);
+            content.setTranslateX(translate);
+        });
 
         setClosable(false);
 
         ribbonGroups.addListener(this::groupsChanged);
         content.getStyleClass().setAll(DEFAULT_STYLE_CLASS, "tab");
         getStyleClass().addListener((ListChangeListener<String>) c -> {
-            while(c.next())
-            {
-                if (c.wasAdded())
-                {
-                    for (String style : c.getAddedSubList())
-                    {
+            while (c.next()) {
+                if (c.wasAdded()) {
+                    c.getAddedSubList().forEach((style) -> {
                         content.getStyleClass().add(style);
-                    }
+                    });
                 }
             }
         });
 
     }
 
-    public void setContextualColor(String color)
-    {
+    public void setContextualColor(String color) {
         contextualColor = color;
         getStyleClass().add(color);
     }
 
-    public String getContextualColor()
-    {
+    public String getContextualColor() {
         return contextualColor;
     }
 
     private void groupsChanged(ListChangeListener.Change<? extends RibbonGroup> changed) {
-        while(changed.next())
-        {
-            if (changed.wasAdded())
-            {
+        while (changed.next()) {
+            if (changed.wasAdded()) {
                 updateAddedGroups(changed.getAddedSubList());
             }
-            if(changed.wasRemoved())
-            {
-                for (RibbonGroup group : changed.getRemoved())
-                {
+            if (changed.wasRemoved()) {
+                for (RibbonGroup group : changed.getRemoved()) {
                     int groupIndex = content.getChildren().indexOf(group);
-                    if (groupIndex != 0)
+                    if (groupIndex != 0) {
                         content.getChildren().remove(groupIndex - 1); // Remove separator
+                    }
                     content.getChildren().remove(group);
 
                 }
@@ -115,15 +116,12 @@ public class RibbonTab extends Tab {
     }
 
     private void updateAddedGroups(List<? extends RibbonGroup> addedSubList) {
-        for (RibbonGroup group : addedSubList)
-        {
+        for (RibbonGroup group : addedSubList) {
             content.getChildren().add(group);
         }
     }
 
-
-    public ObservableList<RibbonGroup> getRibbonGroups()
-    {
+    public ObservableList<RibbonGroup> getRibbonGroups() {
         return ribbonGroups;
     }
 }

--- a/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
+++ b/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
@@ -33,9 +33,6 @@ import javafx.scene.control.Tab;
 import javafx.scene.layout.HBox;
 
 import java.util.List;
-import javafx.event.EventHandler;
-import javafx.scene.control.ScrollPane;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.input.ScrollEvent;
 
 public class RibbonTab extends Tab {

--- a/src/main/resources/com/pixelduke/control/fxribbon.css
+++ b/src/main/resources/com/pixelduke/control/fxribbon.css
@@ -32,6 +32,8 @@
     H1_COLOR: #1550bd;
     RIBBON_BUTTON_COLOR: #7f7f7f;
     RIBBON_BUTTON_HIGHLIGHT_COLOR: #d5e1f2;
+    RIBBON_BUTTON_PRESSED_BACKGROUND_COLOR: #828282;
+    RIBBON_BUTTON_PRESSED_TEXT_COLOR: #FFFFFF;
 
     BUTTON_SELECTED_COLOR: derive(RIBBON_BUTTON_HIGHLIGHT_COLOR, -3%);
 
@@ -260,7 +262,7 @@
 
 .ribbon-group .button:pressed, .ribbon-group .button:default:hover:pressed
 {
-    -fx-background-color: black;
+    -fx-background-color: RIBBON_BUTTON_PRESSED_BACKGROUND_COLOR;
     -fx-text-fill: white;
 }
 

--- a/src/main/resources/com/pixelduke/control/fxribbon.css
+++ b/src/main/resources/com/pixelduke/control/fxribbon.css
@@ -32,7 +32,7 @@
     H1_COLOR: #1550bd;
     RIBBON_BUTTON_COLOR: #7f7f7f;
     RIBBON_BUTTON_HIGHLIGHT_COLOR: #d5e1f2;
-    RIBBON_BUTTON_PRESSED_BACKGROUND_COLOR: #828282;
+    RIBBON_BUTTON_PRESSED_BACKGROUND_COLOR: #000000;
     RIBBON_BUTTON_PRESSED_TEXT_COLOR: #FFFFFF;
 
     BUTTON_SELECTED_COLOR: derive(RIBBON_BUTTON_HIGHLIGHT_COLOR, -3%);
@@ -263,7 +263,7 @@
 .ribbon-group .button:pressed, .ribbon-group .button:default:hover:pressed
 {
     -fx-background-color: RIBBON_BUTTON_PRESSED_BACKGROUND_COLOR;
-    -fx-text-fill: white;
+    -fx-text-fill: RIBBON_BUTTON_PRESSED_TEXT_COLOR;
 }
 
 .ribbon-group .button:focused


### PR DESCRIPTION
Some ribbon groups and ribbon itens get cropped when the stage size is less than the total ribbon tab size. Horizontal scrolling gives users an easy way for accessing that elements without resizing the application window.