### PR TITLE
Fix ribbon groups changed logic

### DIFF
--- a/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
+++ b/src/main/java/com/pixelduke/control/ribbon/RibbonTab.java
@@ -95,29 +95,14 @@ public class RibbonTab extends Tab {
     private void groupsChanged(ListChangeListener.Change<? extends RibbonGroup> changed) {
         while(changed.next())
         {
-            if (changed.wasAdded())
-            {
-                updateAddedGroups(changed.getAddedSubList());
-            }
             if(changed.wasRemoved())
             {
-                for (RibbonGroup group : changed.getRemoved())
-                {
-                    int groupIndex = content.getChildren().indexOf(group);
-                    if (groupIndex != 0)
-                        content.getChildren().remove(groupIndex - 1); // Remove separator
-                    content.getChildren().remove(group);
-
-                }
-
+                content.getChildren().removeAll(changed.getRemoved());
             }
-        }
-    }
-
-    private void updateAddedGroups(List<? extends RibbonGroup> addedSubList) {
-        for (RibbonGroup group : addedSubList)
-        {
-            content.getChildren().add(group);
+            if (changed.wasAdded())
+            {
+                content.getChildren().addAll(changed.getFrom(), changed.getAddedSubList());
+            }
         }
     }
 


### PR DESCRIPTION
While implementing this ribbon menu i found a bug that I have fixed and would like to contribute.

Adding, removing and setting ribbon groups is not working properly. There is no logic to support index adding, and setting ribbon groups. Also, separator is not the direct children of tab's hbox content rather it is of the ribbon group so, there is no need for the logic to remove separator. 

With this fix, all the available add, remove and set methods are supported.